### PR TITLE
flexibility with Tessellation object from geodataframe (squares/adaptive_squares)

### DIFF
--- a/tesspy/tessellation.py
+++ b/tesspy/tessellation.py
@@ -267,7 +267,7 @@ class Tessellation:
             Dataframe containing squares
         """
         df_qk_squares = get_squares_polyfill(self.area_gdf, resolution)
-        df_qk_squares = df_qk_squares.drop(columns=["osm_id", "children_id"])
+        df_qk_squares = df_qk_squares[['geometry', 'quadkey']]
 
         return df_qk_squares
 
@@ -395,7 +395,7 @@ class Tessellation:
             aqk_count_df = df_tmp2
 
         final_aqk = gpd.sjoin(aqk_count_df, self.area_gdf)
-        final_aqk = final_aqk.drop(columns=["osm_id", "children_id", "index_right"])
+        final_aqk = final_aqk[['quadkey', 'count', 'geometry']]
 
         return final_aqk
 


### PR DESCRIPTION
I suggest to get rid of the "drop" statement and replace it with the selection of the columns to keep instead. The reason is that a Tessellation object created using a user-defined GeoDataFrame does likely not have the columns "osm_id" and "children_id", so they can't be dropped and the code results in an error.