### PR TITLE
fix(voronoi): raise clear ValueError when HDBSCAN classifies all points as noise

### DIFF
--- a/tesspy/tessellation.py
+++ b/tesspy/tessellation.py
@@ -342,7 +342,13 @@ class Tessellation:
             clustering = HDBSCAN(
                 min_cluster_size=min_cluster_size,
             ).fit(data_locs)
-            n_clusters = clustering.labels_.max() + 1
+            max_label = clustering.labels_.max()
+            if max_label < 0:
+                raise ValueError(
+                    "HDBSCAN found no clusters (all points classified as noise). "
+                    "Try reducing min_cluster_size."
+                )
+            n_clusters = max_label + 1
             generators = np.empty((n_clusters, 2))
             for label in range(n_clusters):
                 generators[label] = data_locs[clustering.labels_ == label].mean(axis=0)

--- a/tests/unit/test_voronoi.py
+++ b/tests/unit/test_voronoi.py
@@ -3,6 +3,7 @@ Unit tests for Voronoi tessellation functions (no network required).
 """
 
 import numpy as np
+import pytest
 from scipy.spatial import Voronoi
 from shapely.geometry import Polygon
 
@@ -73,3 +74,47 @@ def test_is_generator():
     # Should be a generator, consumable with next()
     first = next(gen)
     assert isinstance(first, Polygon)
+
+
+def test_hdbscan_all_noise_raises_value_error(mocker):
+    """voronoi(cluster_algo='hdbscan') raises ValueError when all points are noise.
+
+    HDBSCAN assigns label -1 to noise points. When min_cluster_size is too large
+    for the dataset, every point gets label -1 and labels_.max() == -1, which
+    previously set n_clusters = 0 and crashed inside scipy.spatial.Voronoi.
+    The fix should raise a clear ValueError instead.
+    """
+    import geopandas as gpd
+    from shapely.geometry import Polygon
+
+    from tesspy.tessellation import Tessellation
+
+    # Build a minimal Tessellation backed by a real GeoDataFrame (no network)
+    area_poly = Polygon([(-0.1, -0.1), (0.1, -0.1), (0.1, 0.1), (-0.1, 0.1)])
+    area_gdf = gpd.GeoDataFrame(geometry=[area_poly], crs="EPSG:4326")
+    t = Tessellation(area_gdf)
+
+    # Inject a small POI dataframe so the method reaches the HDBSCAN branch.
+    # Include the default POI category columns so _get_missing_poi_categories
+    # returns [] and no network call is made.
+    import pandas as pd
+
+    t.poi_dataframe = pd.DataFrame(
+        {
+            "center_longitude": [0.0, 0.01, 0.02],
+            "center_latitude": [0.0, 0.01, 0.02],
+            "amenity": [True, True, True],
+            "building": [False, False, False],
+        }
+    )
+
+    # Patch HDBSCAN so every point is classified as noise (label = -1)
+    mock_clustering = mocker.MagicMock()
+    mock_clustering.labels_ = np.array([-1, -1, -1])
+    mock_hdbscan_cls = mocker.patch(
+        "tesspy.tessellation.HDBSCAN", return_value=mock_clustering
+    )
+    mock_hdbscan_cls.return_value.fit.return_value = mock_clustering
+
+    with pytest.raises(ValueError, match="HDBSCAN found no clusters"):
+        t.voronoi(cluster_algo="hdbscan", min_cluster_size=1000)


### PR DESCRIPTION
## Summary

- **Bug**: When `min_cluster_size` is too large for the dataset, HDBSCAN assigns label `-1` (noise) to every POI point. The code computed `n_clusters = labels_.max() + 1` which evaluated to `0`, then called `scipy.spatial.Voronoi` with an empty array — crashing inside scipy with an unhelpful dimension error.
- **Fix**: Check `max_label < 0` before computing `n_clusters` and raise a descriptive `ValueError` pointing the user to reduce `min_cluster_size`.
- **Test**: Added `test_hdbscan_all_noise_raises_value_error` to `tests/unit/test_voronoi.py` using `pytest-mock` to simulate the all-noise scenario without network access.

## Test plan

- [x] `pytest tests/unit/test_voronoi.py` — all 5 tests pass (including new test)
- [x] New test reproduces the pre-fix crash and confirms the fix raises the right error

🤖 Generated with [Claude Code](https://claude.com/claude-code)