### PR TITLE
fix(voronoi): compute diameter from bounding-box diagonal

### DIFF
--- a/tesspy/tessellation.py
+++ b/tesspy/tessellation.py
@@ -368,8 +368,15 @@ class Tessellation:
             len(generators),
         )
         voronoi_dia = Voronoi(generators)
+        # Compute diameter from bounding box diagonal so infinite Voronoi regions
+        # extend far enough to cover the full study area.  The hardcoded 0.1
+        # (degrees) was too small for any city larger than ~11 km and caused
+        # coverage gaps near the boundary of the generator point set.
+        x_range = generators[:, 0].max() - generators[:, 0].min()
+        y_range = generators[:, 1].max() - generators[:, 1].min()
+        voronoi_diameter = np.sqrt(x_range**2 + y_range**2)
         voronoi_poly = gpd.GeoDataFrame(
-            geometry=list(voronoi_polygons(voronoi_dia, 0.1)), crs="EPSG:4326"
+            geometry=list(voronoi_polygons(voronoi_dia, voronoi_diameter)), crs="EPSG:4326"
         )
         voronoi_poly = gpd.sjoin(voronoi_poly, self.area_gdf)
         vor_polygons = voronoi_poly.intersection(self.area_gdf.geometry.iloc[0])

--- a/tests/unit/test_voronoi.py
+++ b/tests/unit/test_voronoi.py
@@ -73,3 +73,48 @@ def test_is_generator():
     # Should be a generator, consumable with next()
     first = next(gen)
     assert isinstance(first, Polygon)
+
+
+def test_diameter_covers_wide_generator_span():
+    """Voronoi polygons must cover the full bounding box when diameter matches the spread.
+
+    Regression test for tessellation.py hardcoding diameter=0.1.  For generators
+    spanning more than 0.1 units, infinite Voronoi regions were truncated too early,
+    leaving coverage gaps near the edges of the generator set.
+
+    Verifies that a diameter equal to the bounding-box diagonal produces complete
+    coverage, while diameter=0.1 fails for widely-spaced generators.
+    """
+    from shapely.geometry import box
+    from shapely.ops import unary_union
+
+    # Generators spanning 2.0 units — much larger than the old hardcoded 0.1
+    points = np.array(
+        [
+            [0.0, 0.0],
+            [2.0, 0.0],
+            [0.0, 2.0],
+            [2.0, 2.0],
+            [1.0, 1.0],
+        ]
+    )
+    vor = Voronoi(points)
+    bounding_box = box(0.0, 0.0, 2.0, 2.0)
+
+    # With the correct diameter (diagonal ≈ 2.83), coverage should be complete.
+    x_range = points[:, 0].max() - points[:, 0].min()
+    y_range = points[:, 1].max() - points[:, 1].min()
+    diameter = np.sqrt(x_range**2 + y_range**2)
+    polygons = list(voronoi_polygons(vor, diameter))
+
+    union = unary_union(polygons)
+    assert union.covers(bounding_box), (
+        "Voronoi union does not cover bounding box — diameter may be too small"
+    )
+
+    # With the old hardcoded diameter=0.1, coverage fails for wide generator spread
+    small_polygons = list(voronoi_polygons(vor, 0.1))
+    small_union = unary_union(small_polygons)
+    assert not small_union.covers(bounding_box), (
+        "Expected coverage gap with diameter=0.1 for wide generator spread"
+    )


### PR DESCRIPTION
## Summary
- **Bug**: The Voronoi tessellation hardcoded `diameter=0.1` (degrees) when constructing infinite Voronoi regions. For any city spanning more than ~11 km, this caused coverage gaps near the boundary of the generator point set.
- **Fix**: Compute the diameter dynamically from the bounding-box diagonal of the generator points (`sqrt(x_range² + y_range²)`), ensuring infinite regions always extend far enough to cover the full study area.
- **Test**: Added regression test `test_diameter_covers_wide_generator_span` that verifies correct coverage with the dynamic diameter and confirms the old hardcoded value fails for wide generator spreads.

## Test plan
- [x] All existing Voronoi unit tests pass
- [x] New regression test validates the fix and documents the old failure mode
- [ ] Verify CI passes (lint, type check, unit tests across Python 3.11/3.12/3.13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)