### PR TITLE
Fix infinite loop in adaptive_squares when auto-threshold is zero

### DIFF
--- a/tesspy/tessellation.py
+++ b/tesspy/tessellation.py
@@ -212,8 +212,8 @@ class Tessellation:
         df_aqk = get_squares_polyfill(self.area_gdf, start_resolution)
         aqk_count_df = count_poi(df_aqk, poi_data_aqk)
 
-        if not threshold:
-            threshold = int(aqk_count_df["count"].median())
+        if threshold is None:
+            threshold = max(1, int(aqk_count_df["count"].median()))
             log_progress(
                 logger,
                 verbose,

--- a/tests/unit/test_squares.py
+++ b/tests/unit/test_squares.py
@@ -73,3 +73,31 @@ def test_get_adaptive_squares(leisure_poi_berlin):
     max_count = int(count_result["count"].max()) + 1
     unchanged = get_adaptive_squares(count_result, max_count)
     assert len(unchanged) == len(city_squares)
+
+
+def test_get_adaptive_squares_threshold_zero_subdivides_all(leisure_poi_berlin):
+    """Threshold=0 subdivides ALL tiles (count >= 0 is always true).
+
+    This verifies the dangerous edge case that the auto-threshold fix in
+    Tessellation.adaptive_squares guards against: when median POI count
+    is 0 and the old code used ``if not threshold`` instead of
+    ``if threshold is None``, the auto-computed threshold of 0 would
+    cause every tile to be subdivided on every iteration, producing an
+    infinite loop.
+    """
+    from shapely.geometry import box
+
+    mitte_bounds = leisure_poi_berlin.total_bounds
+    mitte_poly = box(*mitte_bounds)
+    mitte_gdf = gpd.GeoDataFrame(geometry=[mitte_poly], crs="EPSG:4326")
+    mitte_gdf["osm_id"] = 0
+
+    city_squares = get_squares_polyfill(mitte_gdf, 14)
+    count_result = count_poi(city_squares, leisure_poi_berlin)
+
+    # threshold=0 means count >= 0, which is true for ALL tiles,
+    # so every single tile gets subdivided into 4 children
+    subdivided = get_adaptive_squares(count_result, 0)
+    assert len(subdivided) > len(city_squares)
+    # In fact every tile is subdivided: each original tile becomes 4 children
+    assert len(subdivided) == len(city_squares) * 4


### PR DESCRIPTION
## Summary

- **Bug**: `adaptive_squares` used `if not threshold:` to detect an omitted threshold argument. When the area is sparse (more than half the tiles contain zero POIs), `int(median) == 0`, and the subdivision loop runs forever — `get_adaptive_squares` subdivides ALL tiles every iteration (since `count >= 0` is always true), consuming unbounded memory until the process crashes.
- **Fix**: Changed `if not threshold:` to `if threshold is None:` so only a truly omitted argument triggers auto-computation, and clamped the auto-computed value to `max(1, ...)` to guarantee the while-loop always terminates.
- **Test**: Added `test_get_adaptive_squares_threshold_zero_subdivides_all` to verify that threshold=0 subdivides all tiles (confirming the dangerous edge case the fix guards against).

## Test plan

- [x] All 87 existing unit tests pass
- [x] New test demonstrates threshold=0 subdivides every tile (4x expansion)
- [ ] Verify with a real sparse area (e.g., rural region) that `adaptive_squares()` with default threshold no longer hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)